### PR TITLE
Feat: port mapping for Django in the devcontainer

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,5 +13,7 @@ services:
       DJANGO_SUPERUSER_PASSWORD: superuser12345!
     # https://code.visualstudio.com/docs/remote/create-dev-container#_use-docker-compose
     entrypoint: sleep infinity
+    ports:
+      - "8000"
     volumes:
       - ./:/home/cdt/src


### PR DESCRIPTION
Follow up to https://github.com/Office-of-Digital-Services/django-cdt-identity/pull/8#pullrequestreview-2610516438

## Reviewing

1. Checkout this branch
2. Rebuild and reopen the devcontainer
3. `F5` to launch the test app
4. Confirm a port mapping for the internal port `8000` to a dynamically assigned `localhost` port, the site is available