### PR TITLE
Feat: `pre_login` hook

### DIFF
--- a/cdt_identity/hooks.py
+++ b/cdt_identity/hooks.py
@@ -1,3 +1,29 @@
+import functools
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def log_hook_call(hook_func):
+    """
+    Decorator that logs a debug message with the hook function's name before executing it.
+
+    Args:
+        hook_func (function): The hook function to decorate.
+
+    Returns:
+        function: The decorated hook function.
+    """
+
+    @functools.wraps(hook_func)
+    def wrapper(*args, **kwargs):
+        logger.debug(f"{hook_func.__name__} hook called")
+        return hook_func(*args, **kwargs)
+
+    return wrapper
+
+
 class DefaultHooks:
     """Default hooks implementation.
 

--- a/cdt_identity/hooks.py
+++ b/cdt_identity/hooks.py
@@ -1,6 +1,8 @@
 import functools
 import logging
 
+from django.http import HttpRequest
+
 
 logger = logging.getLogger(__name__)
 
@@ -47,4 +49,18 @@ class DefaultHooks:
         ```
     """
 
-    pass
+    @classmethod
+    @log_hook_call
+    def pre_login(cls, request: HttpRequest) -> None:
+        """
+        Hook method that runs before initiating login with the Identity Gateway.
+
+        Default Behavior:
+        - No operation is performed.
+
+        Consumers can override this method to execute custom logic before login.
+
+        Args:
+            request (HttpRequest): The incoming Django request object.
+        """
+        pass

--- a/cdt_identity/views.py
+++ b/cdt_identity/views.py
@@ -116,6 +116,7 @@ def login(request: HttpRequest, hooks=DefaultHooks):
     result = None
 
     try:
+        hooks.pre_login(request)
         result = oauth_client.authorize_redirect(request, redirect_uri)
     except Exception as ex:
         exception = ex

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,9 @@
 import logging
 
-from cdt_identity.hooks import log_hook_call
+from django.http import HttpRequest
+import pytest
+
+from cdt_identity.hooks import log_hook_call, DefaultHooks
 
 
 @log_hook_call
@@ -15,3 +18,19 @@ def test_log_hook_call_decorator_logs_debug(caplog):
 
     assert any("dummy_hook hook called" in record.message for record in caplog.records)
     assert result == 6
+
+
+@pytest.mark.parametrize(
+    "hook_func,args",
+    [
+        (DefaultHooks.pre_login, (HttpRequest(),)),
+    ],
+)
+def test_hook_logging(caplog, hook_func, args):
+    """
+    Test that the hook logs the expected debug message.
+    """
+    with caplog.at_level(logging.DEBUG):
+        hook_func(*args)
+
+    assert any(f"{hook_func.__name__} hook called" in record.message for record in caplog.records)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,17 @@
+import logging
+
+from cdt_identity.hooks import log_hook_call
+
+
+@log_hook_call
+def dummy_hook(x):
+    return x * 2
+
+
+def test_log_hook_call_decorator_logs_debug(caplog):
+    """Test that the log_hook_call decorator logs a debug message with the hook function's name."""
+    with caplog.at_level(logging.DEBUG):
+        result = dummy_hook(3)
+
+    assert any("dummy_hook hook called" in record.message for record in caplog.records)
+    assert result == 6


### PR DESCRIPTION
Closes #18 

## What this PR does

This is the first hook implementation, and some helpers/patterns were set up that can be reused for subsequent hooks.

* Decorate a hook method with `@log_hook_call` to get a debug log message with the name of the hook that was called
* Add the decorated hook method to the list of those to unit test for this functionality
* Use the `mock_hooks` fixture to assert the right hooks are called by view functions