### PR TITLE
CI: workflow runs for release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "202[5-9].[0-9][0-9].[0-9]+"
+      - "202[5-9].[0-9][0-9].[0-9]+-rc[0-9]+"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests-pytest.yml
+
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    needs: tests
+    permissions:
+      # https://github.com/softprops/action-gh-release#permissions
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Install build dependencies
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ !contains(github.ref, '-rc') }}
+        with:
+          files: |
+            ./dist/*.tar.gz
+            ./dist/*.whl
+          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
- Requires tests to pass
- Builds the package
- Makes GitHub release, attaching package

Closes #51 